### PR TITLE
Decrement n_probing when removing probing announcer so group doesn't …

### DIFF
--- a/avahi-core/announce.c
+++ b/avahi-core/announce.c
@@ -35,8 +35,14 @@
 #define AVAHI_PROBE_INTERVAL_MSEC 250
 
 static void remove_announcer(AvahiServer *s, AvahiAnnouncer *a) {
+    AvahiEntry *e;
+
     assert(s);
     assert(a);
+    e = a->entry;
+
+    if (a->state == AVAHI_PROBING && e->group)
+        e->group->n_probing--;
 
     if (a->time_event)
         avahi_time_event_free(a->time_event);


### PR DESCRIPTION
…get stuck registering because n_probing can no longer decrement to zero.

Fixes: http://avahi.org/ticket/201, https://github.com/lathiat/avahi/issues/7
Patch was sent to avahi mailing list but was not yet applied: http://lists.freedesktop.org/archives/avahi/2014-March/002291.html