### PR TITLE
Avoid infinite-loop in avahi-daemon by handling HUP event in client_work

### DIFF
--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -424,6 +424,11 @@ static void client_work(AvahiWatch *watch, AVAHI_GCC_UNUSED int fd, AvahiWatchEv
         }
     }
 
+    if (events & AVAHI_WATCH_HUP) {
+        client_free(c);
+        return;
+    }
+
     c->server->poll_api->watch_update(
         watch,
         (c->outbuf_length > 0 ? AVAHI_WATCH_OUT : 0) |


### PR DESCRIPTION
If a client fills the input buffer, client_work() disables the
AVAHI_WATCH_IN event, thus preventing the function from executing the
`read` syscall the next times it is called. However, if the client then
terminates the connection, the socket file descriptor receives a HUP
event, which is not handled, thus the kernel keeps marking the HUP event
as occurring. While iterating over the file descriptors that triggered
an event, the client file descriptor will keep having the HUP event and
the client_work() function is always called with AVAHI_WATCH_HUP but
without nothing being done, thus entering an infinite loop.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=984938