### PR TITLE
Do not disable timeout cleanup on watch cleanup

### DIFF
--- a/avahi-common/simple-watch.c
+++ b/avahi-common/simple-watch.c
@@ -238,7 +238,7 @@ static void cleanup_watches(AvahiSimplePoll *s, int all) {
             destroy_watch(w);
     }
 
-    s->timeout_req_cleanup = 0;
+    s->watch_req_cleanup = 0;
 }
 
 static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata) {


### PR DESCRIPTION
This was causing timeouts to never be removed from the linked list that
tracks them, resulting in both memory and CPU usage to grow larger over
time.