### PR TITLE
Use monotonic clock when possible

### DIFF
--- a/avahi-autoipd/main.c
+++ b/avahi-autoipd/main.c
@@ -785,7 +785,7 @@ int is_ll_address(uint32_t addr) {
 static struct timeval *elapse_time(struct timeval *tv, unsigned msec, unsigned jitter) {
     assert(tv);
 
-    gettimeofday(tv, NULL);
+    avahi_now(tv);
 
     if (msec)
         avahi_timeval_add(tv, (AvahiUsec) msec*1000);

--- a/avahi-autoipd/main.c
+++ b/avahi-autoipd/main.c
@@ -782,7 +782,7 @@ int is_ll_address(uint32_t addr) {
         ((ntohl(addr) & 0x0000FF00) != 0xFF00);
 }
 
-static struct timeval *elapse_time(struct timeval *tv, unsigned msec, unsigned jitter) {
+static struct AvahiTimeVal *elapse_time(struct AvahiTimeVal *tv, unsigned msec, unsigned jitter) {
     assert(tv);
 
     avahi_now(tv);
@@ -1053,7 +1053,7 @@ static int loop(int iface, uint32_t addr) {
     };
 
     int fd = -1, ret = -1;
-    struct timeval next_wakeup;
+    struct AvahiTimeVal next_wakeup;
     int next_wakeup_valid = 0;
     char buf[64];
     ArpPacket *in_packet = NULL;

--- a/avahi-client/browser.c
+++ b/avahi-client/browser.c
@@ -33,6 +33,7 @@
 #include <avahi-common/error.h>
 #include <avahi-common/malloc.h>
 #include <avahi-common/domain.h>
+#include <avahi-common/timeval.h>
 
 #include "client.h"
 #include "internal.h"
@@ -199,7 +200,7 @@ AvahiDomainBrowser* avahi_domain_browser_new(
     }
 
     if (db->static_browse_domains && btype == AVAHI_DOMAIN_BROWSER_BROWSE) {
-        struct timeval tv = { 0, 0 };
+        struct AvahiTimeVal tv = { 0, 0 };
 
         if (!(db->defer_timeout = client->poll_api->timeout_new(client->poll_api, &tv, defer_timeout_callback, db))) {
             avahi_client_set_errno(client, AVAHI_ERR_NO_MEMORY);

--- a/avahi-client/client-test.c
+++ b/avahi-client/client-test.c
@@ -220,7 +220,7 @@ int main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     const char *ret;
     int error;
     uint32_t cookie;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     AvahiAddress a;
 
     simple_poll = avahi_simple_poll_new();

--- a/avahi-common/dbus-watch-glue.c
+++ b/avahi-common/dbus-watch-glue.c
@@ -84,7 +84,7 @@ static void connection_data_unref(ConnectionData *d) {
 }
 
 static void request_dispatch(ConnectionData *d, int enable) {
-    static const struct timeval tv = { 0, 0 };
+    static const struct AvahiTimeVal tv = { 0, 0 };
     assert(d);
 
     if (enable) {
@@ -225,7 +225,7 @@ static void update_timeout(TimeoutData *timeout) {
     assert(timeout->ref >= 1);
 
     if (dbus_timeout_get_enabled(timeout->dbus_timeout)) {
-        struct timeval tv;
+        struct AvahiTimeVal tv;
         avahi_elapse_time(&tv, dbus_timeout_get_interval(timeout->dbus_timeout), 0);
         timeout->poll_api->timeout_update(timeout->
                                       avahi_timeout, &tv);
@@ -254,7 +254,7 @@ static void timeout_callback(AvahiTimeout *avahi_timeout, void *userdata) {
 static dbus_bool_t add_timeout(DBusTimeout *dbus_timeout, void *userdata) {
     TimeoutData *timeout;
     ConnectionData *d = userdata;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     dbus_bool_t b;
 
     assert(dbus_timeout);

--- a/avahi-common/simple-watch.c
+++ b/avahi-common/simple-watch.c
@@ -486,13 +486,12 @@ int avahi_simple_poll_prepare(AvahiSimplePoll *s, int timeout) {
         if (next_timeout->expiry.tv_sec == 0 &&
             next_timeout->expiry.tv_usec == 0) {
 
-            /* Just a shortcut so that we don't need to call gettimeofday() */
+            /* Just a shortcut so that we don't need to call avahi_now() */
             timeout = 0;
             goto finish;
         }
 
-        gettimeofday(&now, NULL);
-        usec = avahi_timeval_diff(&next_timeout->expiry, &now);
+        usec = avahi_timeval_diff(&next_timeout->expiry, avahi_now(&now));
 
         if (usec <= 0) {
             /* Timeout elapsed */
@@ -559,7 +558,7 @@ int avahi_simple_poll_dispatch(AvahiSimplePoll *s) {
 
         if (next_timeout->expiry.tv_sec == 0 && next_timeout->expiry.tv_usec == 0) {
 
-            /* Just a shortcut so that we don't need to call gettimeofday() */
+            /* Just a shortcut so that we don't need to call avahi_now() */
             timeout_callback(next_timeout);
             goto finish;
         }

--- a/avahi-common/simple-watch.c
+++ b/avahi-common/simple-watch.c
@@ -52,7 +52,7 @@ struct AvahiTimeout {
     int dead;
 
     int enabled;
-    struct timeval expiry;
+    struct AvahiTimeVal expiry;
 
     AvahiTimeoutCallback callback;
     void  *userdata;
@@ -241,7 +241,7 @@ static void cleanup_watches(AvahiSimplePoll *s, int all) {
     s->timeout_req_cleanup = 0;
 }
 
-static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata) {
+static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct AvahiTimeVal *tv, AvahiTimeoutCallback callback, void *userdata) {
     AvahiTimeout *t;
     AvahiSimplePoll *s;
 
@@ -270,7 +270,7 @@ static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct timeval *tv,
     return t;
 }
 
-static void timeout_update(AvahiTimeout *t, const struct timeval *tv) {
+static void timeout_update(AvahiTimeout *t, const struct AvahiTimeVal *tv) {
     assert(t);
     assert(!t->dead);
 
@@ -479,7 +479,7 @@ int avahi_simple_poll_prepare(AvahiSimplePoll *s, int timeout) {
 
     /* Calculate the wakeup time */
     if ((next_timeout = find_next_timeout(s))) {
-        struct timeval now;
+        struct AvahiTimeVal now;
         int t;
         AvahiUsec usec;
 

--- a/avahi-common/timeval-test.c
+++ b/avahi-common/timeval-test.c
@@ -28,7 +28,7 @@
 
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
-    struct timeval a = { 5, 5 }, b;
+    struct AvahiTimeVal a = { 5, 5 }, b;
 
     b = a;
 

--- a/avahi-common/timeval.c
+++ b/avahi-common/timeval.c
@@ -33,7 +33,9 @@
 
 #include "timeval.h"
 
-int avahi_timeval_compare(const struct timeval *a, const struct timeval *b) {
+#define USE_MONOTONIC (defined(HAVE_CLOCK_GETTIME) && defined(_POSIX_MONOTONIC_CLOCK))
+
+int avahi_timeval_compare(const struct AvahiTimeVal *a, const struct AvahiTimeVal *b) {
     assert(a);
     assert(b);
 
@@ -52,7 +54,7 @@ int avahi_timeval_compare(const struct timeval *a, const struct timeval *b) {
     return 0;
 }
 
-AvahiUsec avahi_timeval_diff(const struct timeval *a, const struct timeval *b) {
+AvahiUsec avahi_timeval_diff(const struct AvahiTimeVal *a, const struct AvahiTimeVal *b) {
     assert(a);
     assert(b);
 
@@ -62,7 +64,7 @@ AvahiUsec avahi_timeval_diff(const struct timeval *a, const struct timeval *b) {
     return ((AvahiUsec) a->tv_sec - b->tv_sec)*1000000 + a->tv_usec - b->tv_usec;
 }
 
-struct timeval* avahi_timeval_add(struct timeval *a, AvahiUsec usec) {
+struct AvahiTimeVal* avahi_timeval_add(struct AvahiTimeVal *a, AvahiUsec usec) {
     AvahiUsec u;
     assert(a);
 
@@ -79,36 +81,41 @@ struct timeval* avahi_timeval_add(struct timeval *a, AvahiUsec usec) {
     return a;
 }
 
-struct timeval* avahi_now(struct timeval *now) {
+struct AvahiTimeVal* avahi_now(struct AvahiTimeVal *now) {
+    struct timeval tv;
+#if USE_MONOTONIC
+    struct timespec ts;
+#endif
+
     assert(now);
 
-#if defined(HAVE_CLOCK_GETTIME) && defined(_POSIX_MONOTONIC_CLOCK)
-    struct timespec s;
-
+#if USE_MONOTONIC
     /* Use a monotonic clock if possible. This prevents jumps in the system
      * clock from messing with timers (especially jumps backward) */
-    if (clock_gettime(CLOCK_MONOTONIC, &s) == 0) {
-        now->tv_sec = s.tv_sec;
-        now->tv_usec = s.tv_nsec / 1000;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        now->tv_sec = ts.tv_sec;
+        now->tv_usec = ts.tv_nsec / 1000;
     } else {
-        gettimeofday(now, NULL);
+#endif
+        gettimeofday(&tv, NULL);
+        now->tv_sec = tv.tv_sec;
+        now->tv_usec = tv.tv_usec;
+#if USE_MONOTONIC
     }
-#else
-    gettimeofday(now, NULL);
 #endif
 
     return now;
 }
 
-AvahiUsec avahi_age(const struct timeval *a) {
-    struct timeval now;
+AvahiUsec avahi_age(const struct AvahiTimeVal *a) {
+    struct AvahiTimeVal now;
 
     assert(a);
 
     return avahi_timeval_diff(avahi_now(&now), a);
 }
 
-struct timeval *avahi_elapse_time(struct timeval *tv, unsigned msec, unsigned jitter) {
+struct AvahiTimeVal *avahi_elapse_time(struct AvahiTimeVal *tv, unsigned msec, unsigned jitter) {
     assert(tv);
 
     avahi_now(tv);

--- a/avahi-common/timeval.h
+++ b/avahi-common/timeval.h
@@ -41,6 +41,11 @@ AvahiUsec avahi_timeval_diff(const struct timeval *a, const struct timeval *b);
 /** Add a number of microseconds to the specified timeval structure and return it. *a is modified. */
 struct timeval* avahi_timeval_add(struct timeval *a, AvahiUsec usec);
 
+/** Get the current timestamp. This will return a monotonic clock if possible,
+ * so it should not be used if you need a timeval for display or comparison
+ * with gettimeofday(). Returns the input timeval */
+struct timeval* avahi_now(struct timeval *now);
+
 /** Return the difference between the current time and *a. Positive if *a was earlier */
 AvahiUsec avahi_age(const struct timeval *a);
 

--- a/avahi-common/timeval.h
+++ b/avahi-common/timeval.h
@@ -29,30 +29,37 @@
 
 AVAHI_C_DECL_BEGIN
 
+/** Structure for tracking time. Mirrors struct timeval, but is not equivalent
+ * because an AvahiTimeVal may be from the monotonic timer */
+struct AvahiTimeVal {
+    time_t tv_sec; /* seconds */
+    long tv_usec; /* microseconds */
+};
+
 /** A numeric data type for storing microsecond values. (signed 64bit integer) */
 typedef int64_t AvahiUsec;
 
-/** Compare two timeval structures and return a negative value when a < b, 0 when a == b and a positive value otherwise */
-int avahi_timeval_compare(const struct timeval *a, const struct timeval *b);
+/** Compare two AvahiTimeVal structures and return a negative value when a < b, 0 when a == b and a positive value otherwise */
+int avahi_timeval_compare(const struct AvahiTimeVal *a, const struct AvahiTimeVal *b);
 
-/** Calculate the difference between two timeval structures as microsecond value */
-AvahiUsec avahi_timeval_diff(const struct timeval *a, const struct timeval *b);
+/** Calculate the difference between two AvahiTimeVal structures as microsecond value */
+AvahiUsec avahi_timeval_diff(const struct AvahiTimeVal *a, const struct AvahiTimeVal *b);
 
-/** Add a number of microseconds to the specified timeval structure and return it. *a is modified. */
-struct timeval* avahi_timeval_add(struct timeval *a, AvahiUsec usec);
+/** Add a number of microseconds to the specified AvahiTimeVal structure and return it. *a is modified. */
+struct AvahiTimeVal* avahi_timeval_add(struct AvahiTimeVal *a, AvahiUsec usec);
 
 /** Get the current timestamp. This will return a monotonic clock if possible,
- * so it should not be used if you need a timeval for display or comparison
- * with gettimeofday(). Returns the input timeval */
-struct timeval* avahi_now(struct timeval *now);
+ * so it should not be used if you need a AvahiTimeVal for display or comparison
+ * with gettimeofday(). Returns the input AvahiTimeVal */
+struct AvahiTimeVal* avahi_now(struct AvahiTimeVal *now);
 
 /** Return the difference between the current time and *a. Positive if *a was earlier */
-AvahiUsec avahi_age(const struct timeval *a);
+AvahiUsec avahi_age(const struct AvahiTimeVal *a);
 
 /** Fill *tv with the current time plus "ms" milliseconds plus an
  * extra jitter of "j" milliseconds. Pass 0 for j if you don't want
  * the jitter */
-struct timeval *avahi_elapse_time(struct timeval *tv, unsigned ms, unsigned j);
+struct AvahiTimeVal *avahi_elapse_time(struct AvahiTimeVal *tv, unsigned ms, unsigned j);
 
 AVAHI_C_DECL_END
 

--- a/avahi-common/watch-test.c
+++ b/avahi-common/watch-test.c
@@ -59,7 +59,7 @@ static void callback(AvahiWatch *w, int fd, AvahiWatchEvent event, AVAHI_GCC_UNU
 
 static void wakeup(AvahiTimeout *t, AVAHI_GCC_UNUSED void *userdata) {
     static int i = 0;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     printf("Wakeup #%i\n", i++);
 
@@ -76,7 +76,7 @@ static void wakeup(AvahiTimeout *t, AVAHI_GCC_UNUSED void *userdata) {
 }
 
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
 #ifndef USE_THREAD
     simple_poll = avahi_simple_poll_new();

--- a/avahi-common/watch.h
+++ b/avahi-common/watch.h
@@ -26,6 +26,7 @@
 #include <sys/time.h>
 
 #include <avahi-common/cdecl.h>
+#include <avahi-common/timeval.h>
 
 AVAHI_C_DECL_BEGIN
 
@@ -81,11 +82,11 @@ struct AvahiPoll {
     NULL, the timeout is disabled. After the timeout expired the
     callback function will be called and the timeout is disabled. You
     can reenable it by calling timeout_update()  */
-    AvahiTimeout* (*timeout_new)(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata);
+    AvahiTimeout* (*timeout_new)(const AvahiPoll *api, const struct AvahiTimeVal *tv, AvahiTimeoutCallback callback, void *userdata);
 
     /** Update the absolute expiration time for a timeout, If tv is
      * NULL, the timeout is disabled. It is safe to call this function from an AvahiTimeoutCallback */
-    void (*timeout_update)(AvahiTimeout *, const struct timeval *tv);
+    void (*timeout_update)(AvahiTimeout *, const struct AvahiTimeVal *tv);
 
     /** Free a timeout. It is safe to call this function from an AvahiTimeoutCallback */
     void (*timeout_free)(AvahiTimeout *t);

--- a/avahi-core/announce.c
+++ b/avahi-core/announce.c
@@ -49,7 +49,7 @@ static void remove_announcer(AvahiServer *s, AvahiAnnouncer *a) {
 
 static void elapse_announce(AvahiTimeEvent *e, void *userdata);
 
-static void set_timeout(AvahiAnnouncer *a, const struct timeval *tv) {
+static void set_timeout(AvahiAnnouncer *a, const struct AvahiTimeVal *tv) {
     assert(a);
 
     if (!tv) {
@@ -99,7 +99,7 @@ void avahi_s_entry_group_check_probed(AvahiSEntryGroup *g, int immediately) {
                 a->n_iteration = 1;
                 next_state(a);
             } else {
-                struct timeval tv;
+                struct AvahiTimeVal tv;
                 a->n_iteration = 0;
                 avahi_elapse_time(&tv, 0, AVAHI_ANNOUNCEMENT_JITTER_MSEC);
                 set_timeout(a, &tv);
@@ -137,7 +137,7 @@ static void next_state(AvahiAnnouncer *a) {
             set_timeout(a, NULL);
             next_state(a);
         } else {
-            struct timeval tv;
+            struct AvahiTimeVal tv;
 
             avahi_interface_post_probe(a->interface, a->entry->record, 0);
 
@@ -164,7 +164,7 @@ static void next_state(AvahiAnnouncer *a) {
 
             set_timeout(a, NULL);
         } else {
-            struct timeval tv;
+            struct AvahiTimeVal tv;
             avahi_elapse_time(&tv, a->sec_delay*1000, AVAHI_ANNOUNCEMENT_JITTER_MSEC);
 
             if (a->n_iteration < 10)
@@ -197,7 +197,7 @@ static AvahiAnnouncer *get_announcer(AvahiServer *s, AvahiEntry *e, AvahiInterfa
 
 static void go_to_initial_state(AvahiAnnouncer *a) {
     AvahiEntry *e;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(a);
     e = a->entry;
@@ -416,7 +416,7 @@ static void send_goodbye_callback(AvahiInterfaceMonitor *m, AvahiInterface *i, v
 
 static void reannounce(AvahiAnnouncer *a) {
     AvahiEntry *e;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(a);
     e = a->entry;

--- a/avahi-core/avahi-test.c
+++ b/avahi-core/avahi-test.c
@@ -58,7 +58,7 @@ static void dump_line(const char *text, AVAHI_GCC_UNUSED void* userdata) {
 }
 
 static void dump_timeout_callback(AvahiTimeout *timeout, void* userdata) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     AvahiServer *avahi = userdata;
     avahi_server_dump(avahi, dump_line, NULL);
@@ -338,7 +338,7 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     AvahiSDNSServerBrowser *dsb;
     AvahiSimplePoll *simple_poll;
     int error;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     simple_poll = avahi_simple_poll_new();
     poll_api = avahi_simple_poll_get(simple_poll);

--- a/avahi-core/cache.c
+++ b/avahi-core/cache.c
@@ -268,7 +268,7 @@ static void expire_in_one_second(AvahiCache *c, AvahiCacheEntry *e, AvahiCacheEn
     assert(e);
 
     e->state = state;
-    gettimeofday(&e->expiry, NULL);
+    avahi_now(&e->expiry);
     avahi_timeval_add(&e->expiry, 1000000); /* 1s */
     update_time_event(c, e);
 }
@@ -293,7 +293,7 @@ void avahi_cache_update(AvahiCache *c, AvahiRecord *r, int cache_flush, const Av
         AvahiCacheEntry *e = NULL, *first;
         struct timeval now;
 
-        gettimeofday(&now, NULL);
+        avahi_now(&now);
 
         /* This is an update request */
 
@@ -421,7 +421,7 @@ int avahi_cache_entry_half_ttl(AvahiCache *c, AvahiCacheEntry *e) {
     assert(c);
     assert(e);
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     age = (unsigned) (avahi_timeval_diff(&now, &e->timestamp)/1000000);
 
@@ -448,7 +448,7 @@ static void* start_poof_callback(AvahiCache *c, AvahiKey *pattern, AvahiCacheEnt
     assert(e);
     assert(a);
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     switch (e->state) {
         case AVAHI_CACHE_VALID:

--- a/avahi-core/cache.c
+++ b/avahi-core/cache.c
@@ -291,7 +291,7 @@ void avahi_cache_update(AvahiCache *c, AvahiRecord *r, int cache_flush, const Av
 
     } else {
         AvahiCacheEntry *e = NULL, *first;
-        struct timeval now;
+        struct AvahiTimeVal now;
 
         avahi_now(&now);
 
@@ -415,7 +415,7 @@ int avahi_cache_dump(AvahiCache *c, AvahiDumpCallback callback, void* userdata) 
 }
 
 int avahi_cache_entry_half_ttl(AvahiCache *c, AvahiCacheEntry *e) {
-    struct timeval now;
+    struct AvahiTimeVal now;
     unsigned age;
 
     assert(c);
@@ -441,7 +441,7 @@ void avahi_cache_flush(AvahiCache *c) {
 
 static void* start_poof_callback(AvahiCache *c, AvahiKey *pattern, AvahiCacheEntry *e, void *userdata) {
     AvahiAddress *a = userdata;
-    struct timeval now;
+    struct AvahiTimeVal now;
 
     assert(c);
     assert(pattern);

--- a/avahi-core/cache.h
+++ b/avahi-core/cache.h
@@ -45,9 +45,9 @@ typedef struct AvahiCacheEntry AvahiCacheEntry;
 struct AvahiCacheEntry {
     AvahiCache *cache;
     AvahiRecord *record;
-    struct timeval timestamp;
-    struct timeval poof_timestamp;
-    struct timeval expiry;
+    struct AvahiTimeVal timestamp;
+    struct AvahiTimeVal poof_timestamp;
+    struct AvahiTimeVal expiry;
     int cache_flush;
     int poof_num;
 

--- a/avahi-core/conformance-test.c
+++ b/avahi-core/conformance-test.c
@@ -52,7 +52,7 @@ static void dump_line(const char *text, AVAHI_GCC_UNUSED void* userdata) {
 }
 
 static void dump_timeout_callback(AvahiTimeout *timeout, AVAHI_GCC_UNUSED void* userdata) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     avahi_server_dump(avahi, dump_line, NULL);
 
@@ -83,7 +83,7 @@ static void create_service(const char *t) {
 }
 
 static void rename_timeout_callback(AvahiTimeout *timeout, AVAHI_GCC_UNUSED void *userdata) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     if (access("flag", F_OK) == 0) {
         create_service("New - Bonjour Service Name");
@@ -122,7 +122,7 @@ static void server_callback(AvahiServer *s, AvahiServerState state, AVAHI_GCC_UN
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     int error;
     AvahiSimplePoll *simple_poll;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     struct AvahiServerConfig config;
 
     simple_poll = avahi_simple_poll_new();

--- a/avahi-core/entry.c
+++ b/avahi-core/entry.c
@@ -1034,7 +1034,7 @@ void avahi_s_entry_group_change_state(AvahiSEntryGroup *g, AvahiEntryGroupState 
         /* If the entry group is now established, remember the time
          * this happened */
 
-        gettimeofday(&g->established_at, NULL);
+        avahi_now(&g->established_at);
 
     g->state = state;
 
@@ -1114,7 +1114,7 @@ void avahi_s_entry_group_free(AvahiSEntryGroup *g) {
 static void entry_group_commit_real(AvahiSEntryGroup *g) {
     assert(g);
 
-    gettimeofday(&g->register_time, NULL);
+    avahi_now(&g->register_time);
 
     avahi_s_entry_group_change_state(g, AVAHI_ENTRY_GROUP_REGISTERING);
 
@@ -1155,7 +1155,7 @@ int avahi_s_entry_group_commit(AvahiSEntryGroup *g) {
                             AVAHI_RR_HOLDOFF_MSEC_RATE_LIMIT :
                             AVAHI_RR_HOLDOFF_MSEC));
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     if (avahi_timeval_compare(&g->register_time, &now) <= 0) {
 

--- a/avahi-core/entry.c
+++ b/avahi-core/entry.c
@@ -1077,7 +1077,7 @@ static void cleanup_time_event_callback(AVAHI_GCC_UNUSED AvahiTimeEvent *e, void
 }
 
 static void schedule_cleanup(AvahiServer *s) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(s);
 
@@ -1137,7 +1137,7 @@ static void entry_group_register_time_event_callback(AVAHI_GCC_UNUSED AvahiTimeE
 }
 
 int avahi_s_entry_group_commit(AvahiSEntryGroup *g) {
-    struct timeval now;
+    struct AvahiTimeVal now;
 
     assert(g);
     assert(!g->dead);

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -576,7 +576,7 @@ void avahi_interface_send_packet_unicast(AvahiInterface *i, AvahiDnsPacket *p, c
     assert(!a || a->proto == i->protocol);
 
     if (i->monitor->server->config.ratelimit_interval > 0) {
-        struct timeval now, end;
+        struct AvahiTimeVal now, end;
 
         avahi_now(&now);
 

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -29,6 +29,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
+#include <avahi-common/timeval.h>
 #include <avahi-common/error.h>
 #include <avahi-common/malloc.h>
 #include <avahi-common/domain.h>
@@ -577,7 +578,7 @@ void avahi_interface_send_packet_unicast(AvahiInterface *i, AvahiDnsPacket *p, c
     if (i->monitor->server->config.ratelimit_interval > 0) {
         struct timeval now, end;
 
-        gettimeofday(&now, NULL);
+        avahi_now(&now);
 
         end = i->hardware->ratelimit_begin;
         avahi_timeval_add(&end, i->monitor->server->config.ratelimit_interval);

--- a/avahi-core/iface.h
+++ b/avahi-core/iface.h
@@ -86,7 +86,7 @@ struct AvahiHwInterface {
     AvahiSEntryGroup *entry_group;
 
     /* Packet rate limiting */
-    struct timeval ratelimit_begin;
+    struct AvahiTimeVal ratelimit_begin;
     unsigned ratelimit_counter;
 
     AVAHI_LLIST_HEAD(AvahiInterface, interfaces);

--- a/avahi-core/internal.h
+++ b/avahi-core/internal.h
@@ -57,7 +57,7 @@ struct AvahiLegacyUnicastReflectSlot {
     AvahiAddress address;
     uint16_t port;
     int interface;
-    struct timeval elapse_time;
+    struct AvahiTimeVal elapse_time;
     AvahiTimeEvent *time_event;
 };
 
@@ -90,10 +90,10 @@ struct AvahiSEntryGroup {
     unsigned n_probing;
 
     unsigned n_register_try;
-    struct timeval register_time;
+    struct AvahiTimeVal register_time;
     AvahiTimeEvent *register_time_event;
 
-    struct timeval established_at;
+    struct AvahiTimeVal established_at;
 
     AVAHI_LLIST_FIELDS(AvahiSEntryGroup, groups);
     AVAHI_LLIST_HEAD(AvahiEntry, entries);

--- a/avahi-core/multicast-lookup.c
+++ b/avahi-core/multicast-lookup.c
@@ -85,7 +85,7 @@ AvahiMulticastLookup *avahi_multicast_lookup_new(
     void *userdata) {
 
     AvahiMulticastLookup *l, *t;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(e);
     assert(AVAHI_IF_VALID(interface));

--- a/avahi-core/probe-sched.c
+++ b/avahi-core/probe-sched.c
@@ -124,7 +124,7 @@ static void job_mark_done(AvahiProbeScheduler *s, AvahiProbeJob *pj) {
     pj->done = 1;
 
     job_set_elapse_time(s, pj, AVAHI_PROBE_HISTORY_MSEC, 0);
-    gettimeofday(&pj->delivery, NULL);
+    avahi_now(&pj->delivery);
 }
 
 AvahiProbeScheduler *avahi_probe_scheduler_new(AvahiInterface *i) {

--- a/avahi-core/probe-sched.c
+++ b/avahi-core/probe-sched.c
@@ -42,7 +42,7 @@ struct AvahiProbeJob {
 
     int chosen; /* Use for packet assembling */
     int done;
-    struct timeval delivery;
+    struct AvahiTimeVal delivery;
 
     AvahiRecord *record;
 
@@ -99,7 +99,7 @@ static void job_free(AvahiProbeScheduler *s, AvahiProbeJob *pj) {
 static void elapse_callback(AvahiTimeEvent *e, void* data);
 
 static void job_set_elapse_time(AvahiProbeScheduler *s, AvahiProbeJob *pj, unsigned msec, unsigned jitter) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(s);
     assert(pj);
@@ -367,7 +367,7 @@ static AvahiProbeJob* find_history_job(AvahiProbeScheduler *s, AvahiRecord *reco
 
 int avahi_probe_scheduler_post(AvahiProbeScheduler *s, AvahiRecord *record, int immediately) {
     AvahiProbeJob *pj;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(s);
     assert(record);

--- a/avahi-core/querier-test.c
+++ b/avahi-core/querier-test.c
@@ -80,7 +80,7 @@ static void quit(AVAHI_GCC_UNUSED AvahiTimeout *timeout, AVAHI_GCC_UNUSED void *
 }
 
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     AvahiServerConfig config;
 
     simple_poll = avahi_simple_poll_new();

--- a/avahi-core/querier.c
+++ b/avahi-core/querier.c
@@ -124,7 +124,7 @@ void avahi_querier_add(AvahiInterface *i, AvahiKey *key, struct timeval *ret_cti
     q->n_used = 1;
     q->sec_delay = 1;
     q->post_id_valid = 0;
-    gettimeofday(&q->creation_time, NULL);
+    avahi_now(&q->creation_time);
 
     /* Do the initial query */
     if (avahi_interface_post_query(i, key, 0, &q->post_id))

--- a/avahi-core/querier.c
+++ b/avahi-core/querier.c
@@ -41,7 +41,7 @@ struct AvahiQuerier {
 
     AvahiTimeEvent *time_event;
 
-    struct timeval creation_time;
+    struct AvahiTimeVal creation_time;
 
     unsigned post_id;
     int post_id_valid;
@@ -63,7 +63,7 @@ void avahi_querier_free(AvahiQuerier *q) {
 
 static void querier_elapse_callback(AVAHI_GCC_UNUSED AvahiTimeEvent *e, void *userdata) {
     AvahiQuerier *q = userdata;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(q);
 
@@ -95,9 +95,9 @@ static void querier_elapse_callback(AVAHI_GCC_UNUSED AvahiTimeEvent *e, void *us
     avahi_time_event_update(q->time_event, &tv);
 }
 
-void avahi_querier_add(AvahiInterface *i, AvahiKey *key, struct timeval *ret_ctime) {
+void avahi_querier_add(AvahiInterface *i, AvahiKey *key, struct AvahiTimeVal *ret_ctime) {
     AvahiQuerier *q;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(i);
     assert(key);
@@ -188,7 +188,7 @@ void avahi_querier_remove_for_all(AvahiServer *s, AvahiIfIndex idx, AvahiProtoco
 
 struct cbdata {
     AvahiKey *key;
-    struct timeval *ret_ctime;
+    struct AvahiTimeVal *ret_ctime;
 };
 
 static void add_querier_callback(AvahiInterfaceMonitor *m, AvahiInterface *i, void* userdata) {
@@ -199,7 +199,7 @@ static void add_querier_callback(AvahiInterfaceMonitor *m, AvahiInterface *i, vo
     assert(cbdata);
 
     if (i->announcing) {
-        struct timeval tv;
+        struct AvahiTimeVal tv;
         avahi_querier_add(i, cbdata->key, &tv);
 
         if (cbdata->ret_ctime && avahi_timeval_compare(&tv, cbdata->ret_ctime) > 0)
@@ -207,7 +207,7 @@ static void add_querier_callback(AvahiInterfaceMonitor *m, AvahiInterface *i, vo
     }
 }
 
-void avahi_querier_add_for_all(AvahiServer *s, AvahiIfIndex idx, AvahiProtocol protocol, AvahiKey *key, struct timeval *ret_ctime) {
+void avahi_querier_add_for_all(AvahiServer *s, AvahiIfIndex idx, AvahiProtocol protocol, AvahiKey *key, struct AvahiTimeVal *ret_ctime) {
     struct cbdata cbdata;
 
     assert(s);
@@ -248,7 +248,7 @@ int avahi_querier_shall_refresh_cache(AvahiInterface *i, AvahiKey *key) {
         return 0;
 
     } else {
-        struct timeval tv;
+        struct AvahiTimeVal tv;
 
         /* We can defer our query a little, since the cache will now
          * issue a refresh query anyway. */

--- a/avahi-core/querier.h
+++ b/avahi-core/querier.h
@@ -25,13 +25,13 @@ typedef struct AvahiQuerier AvahiQuerier;
 #include "iface.h"
 
 /** Add querier for the specified key to the specified interface */
-void avahi_querier_add(AvahiInterface *i, AvahiKey *key, struct timeval *ret_ctime);
+void avahi_querier_add(AvahiInterface *i, AvahiKey *key, struct AvahiTimeVal *ret_ctime);
 
 /** Remove a querier for the specified key from the specified interface */
 void avahi_querier_remove(AvahiInterface *i, AvahiKey *key);
 
 /** Add a querier for the specified key on all interfaces that mach */
-void avahi_querier_add_for_all(AvahiServer *s, AvahiIfIndex idx, AvahiProtocol protocol, AvahiKey *key, struct timeval *ret_ctime);
+void avahi_querier_add_for_all(AvahiServer *s, AvahiIfIndex idx, AvahiProtocol protocol, AvahiKey *key, struct AvahiTimeVal *ret_ctime);
 
 /** Remove a querier for the specified key on all interfaces that mach */
 void avahi_querier_remove_for_all(AvahiServer *s, AvahiIfIndex idx, AvahiProtocol protocol, AvahiKey *key);

--- a/avahi-core/query-sched.c
+++ b/avahi-core/query-sched.c
@@ -43,7 +43,7 @@ struct AvahiQueryJob {
     AvahiTimeEvent *time_event;
 
     int done;
-    struct timeval delivery;
+    struct AvahiTimeVal delivery;
 
     AvahiKey *key;
 
@@ -120,7 +120,7 @@ static void job_free(AvahiQueryScheduler *s, AvahiQueryJob *qj) {
 static void elapse_callback(AvahiTimeEvent *e, void* data);
 
 static void job_set_elapse_time(AvahiQueryScheduler *s, AvahiQueryJob *qj, unsigned msec, unsigned jitter) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(s);
     assert(qj);
@@ -352,7 +352,7 @@ static AvahiQueryJob* find_history_job(AvahiQueryScheduler *s, AvahiKey *key) {
 }
 
 int avahi_query_scheduler_post(AvahiQueryScheduler *s, AvahiKey *key, int immediately, unsigned *ret_id) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     AvahiQueryJob *qj;
 
     assert(s);

--- a/avahi-core/query-sched.c
+++ b/avahi-core/query-sched.c
@@ -145,7 +145,7 @@ static void job_mark_done(AvahiQueryScheduler *s, AvahiQueryJob *qj) {
     qj->done = 1;
 
     job_set_elapse_time(s, qj, AVAHI_QUERY_HISTORY_MSEC, 0);
-    gettimeofday(&qj->delivery, NULL);
+    avahi_now(&qj->delivery);
 }
 
 AvahiQueryScheduler *avahi_query_scheduler_new(AvahiInterface *i) {
@@ -411,7 +411,7 @@ void avahi_query_scheduler_incoming(AvahiQueryScheduler *s, AvahiKey *key) {
         if (!(qj = job_new(s, key, 1)))
             return; /* OOM */
 
-    gettimeofday(&qj->delivery, NULL);
+    avahi_now(&qj->delivery);
     job_set_elapse_time(s, qj, AVAHI_QUERY_HISTORY_MSEC, 0);
 }
 

--- a/avahi-core/resolve-address.c
+++ b/avahi-core/resolve-address.c
@@ -85,7 +85,7 @@ static void time_event_callback(AvahiTimeEvent *e, void *userdata) {
 }
 
 static void start_timeout(AvahiSAddressResolver *r) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     assert(r);
 
     if (r->time_event)

--- a/avahi-core/resolve-host-name.c
+++ b/avahi-core/resolve-host-name.c
@@ -105,7 +105,7 @@ static void time_event_callback(AvahiTimeEvent *e, void *userdata) {
 }
 
 static void start_timeout(AvahiSHostNameResolver *r) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     assert(r);
 
     if (r->time_event)

--- a/avahi-core/resolve-service.c
+++ b/avahi-core/resolve-service.c
@@ -152,7 +152,7 @@ static void time_event_callback(AvahiTimeEvent *e, void *userdata) {
 }
 
 static void start_timeout(AvahiSServiceResolver *r) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     assert(r);
 
     if (r->time_event)

--- a/avahi-core/response-sched.c
+++ b/avahi-core/response-sched.c
@@ -148,7 +148,7 @@ static void job_mark_done(AvahiResponseScheduler *s, AvahiResponseJob *rj) {
 
     job_set_elapse_time(s, rj, AVAHI_RESPONSE_HISTORY_MSEC, 0);
 
-    gettimeofday(&rj->delivery, NULL);
+    avahi_now(&rj->delivery);
 }
 
 AvahiResponseScheduler *avahi_response_scheduler_new(AvahiInterface *i) {
@@ -460,7 +460,7 @@ void avahi_response_scheduler_incoming(AvahiResponseScheduler *s, AvahiRecord *r
     rj->flush_cache = flush_cache;
     rj->querier_valid = 0;
 
-    gettimeofday(&rj->delivery, NULL);
+    avahi_now(&rj->delivery);
     job_set_elapse_time(s, rj, AVAHI_RESPONSE_HISTORY_MSEC, 0);
 }
 
@@ -498,7 +498,7 @@ void avahi_response_scheduler_suppress(AvahiResponseScheduler *s, AvahiRecord *r
         rj->querier = *querier;
     }
 
-    gettimeofday(&rj->delivery, NULL);
+    avahi_now(&rj->delivery);
     job_set_elapse_time(s, rj, AVAHI_RESPONSE_SUPPRESS_MSEC, 0);
 }
 

--- a/avahi-core/response-sched.c
+++ b/avahi-core/response-sched.c
@@ -55,7 +55,7 @@ struct AvahiResponseJob {
     AvahiTimeEvent *time_event;
 
     AvahiResponseJobState state;
-    struct timeval delivery;
+    struct AvahiTimeVal delivery;
 
     AvahiRecord *record;
     int flush_cache;
@@ -122,7 +122,7 @@ static void job_free(AvahiResponseScheduler *s, AvahiResponseJob *rj) {
 static void elapse_callback(AvahiTimeEvent *e, void* data);
 
 static void job_set_elapse_time(AvahiResponseScheduler *s, AvahiResponseJob *rj, unsigned msec, unsigned jitter) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(s);
     assert(rj);
@@ -346,7 +346,7 @@ static AvahiResponseJob* find_suppressed_job(AvahiResponseScheduler *s, AvahiRec
 
 int avahi_response_scheduler_post(AvahiResponseScheduler *s, AvahiRecord *record, int flush_cache, const AvahiAddress *querier, int immediately) {
     AvahiResponseJob *rj;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 /*     char *t; */
 
     assert(s);

--- a/avahi-core/timeeventq-test.c
+++ b/avahi-core/timeeventq-test.c
@@ -36,7 +36,7 @@
 static AvahiTimeEventQueue *q = NULL;
 
 static void callback(AvahiTimeEvent*e, void* userdata) {
-    struct timeval tv = {0, 0};
+    struct AvahiTimeVal tv = {0, 0};
     assert(e);
     avahi_log_info("callback(%i)", POINTER_TO_INT(userdata));
     avahi_elapse_time(&tv, 1000, 100);
@@ -44,7 +44,7 @@ static void callback(AvahiTimeEvent*e, void* userdata) {
 }
 
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     AvahiSimplePoll *s;
 
     s = avahi_simple_poll_new();

--- a/avahi-core/timeeventq.c
+++ b/avahi-core/timeeventq.c
@@ -80,7 +80,7 @@ static void expiration_event(AVAHI_GCC_UNUSED AvahiTimeout *timeout, void *userd
     if ((e = time_event_queue_root(q))) {
         struct timeval now;
 
-        gettimeofday(&now, NULL);
+        avahi_now(&now);
 
         /* Check if expired */
         if (avahi_timeval_compare(&now, &e->expiry) >= 0) {
@@ -108,7 +108,7 @@ static void fix_expiry_time(AvahiTimeEvent *e) {
 
     return; /*** DO WE REALLY NEED THIS? ***/
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     if (avahi_timeval_compare(&now, &e->expiry) > 0)
         e->expiry = now;

--- a/avahi-core/timeeventq.c
+++ b/avahi-core/timeeventq.c
@@ -33,8 +33,8 @@
 struct AvahiTimeEvent {
     AvahiTimeEventQueue *queue;
     AvahiPrioQueueNode *node;
-    struct timeval expiry;
-    struct timeval last_run;
+    struct AvahiTimeVal expiry;
+    struct AvahiTimeVal last_run;
     AvahiTimeEventCallback callback;
     void* userdata;
 };
@@ -78,7 +78,7 @@ static void expiration_event(AVAHI_GCC_UNUSED AvahiTimeout *timeout, void *userd
     AvahiTimeEvent *e;
 
     if ((e = time_event_queue_root(q))) {
-        struct timeval now;
+        struct AvahiTimeVal now;
 
         avahi_now(&now);
 
@@ -103,7 +103,7 @@ static void expiration_event(AVAHI_GCC_UNUSED AvahiTimeout *timeout, void *userd
 }
 
 static void fix_expiry_time(AvahiTimeEvent *e) {
-    struct timeval now;
+    struct AvahiTimeVal now;
     assert(e);
 
     return; /*** DO WE REALLY NEED THIS? ***/
@@ -160,7 +160,7 @@ void avahi_time_event_queue_free(AvahiTimeEventQueue *q) {
 
 AvahiTimeEvent* avahi_time_event_new(
     AvahiTimeEventQueue *q,
-    const struct timeval *timeval,
+    const struct AvahiTimeVal *timeval,
     AvahiTimeEventCallback callback,
     void* userdata) {
 
@@ -212,7 +212,7 @@ void avahi_time_event_free(AvahiTimeEvent *e) {
     update_timeout(q);
 }
 
-void avahi_time_event_update(AvahiTimeEvent *e, const struct timeval *timeval) {
+void avahi_time_event_update(AvahiTimeEvent *e, const struct AvahiTimeVal *timeval) {
     assert(e);
     assert(timeval);
 

--- a/avahi-core/timeeventq.h
+++ b/avahi-core/timeeventq.h
@@ -36,11 +36,11 @@ void avahi_time_event_queue_free(AvahiTimeEventQueue *q);
 
 AvahiTimeEvent* avahi_time_event_new(
     AvahiTimeEventQueue *q,
-    const struct timeval *timeval,
+    const struct AvahiTimeVal *timeval,
     AvahiTimeEventCallback callback,
     void* userdata);
 
 void avahi_time_event_free(AvahiTimeEvent *e);
-void avahi_time_event_update(AvahiTimeEvent *e, const struct timeval *timeval);
+void avahi_time_event_update(AvahiTimeEvent *e, const struct AvahiTimeVal *timeval);
 
 #endif

--- a/avahi-core/update-test.c
+++ b/avahi-core/update-test.c
@@ -69,7 +69,7 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     AvahiSimplePoll *simple_poll;
     const AvahiPoll *poll_api;
     AvahiServer *server;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     AvahiServerConfig config;
 
     simple_poll = avahi_simple_poll_new();

--- a/avahi-core/wide-area.c
+++ b/avahi-core/wide-area.c
@@ -437,7 +437,7 @@ static void add_to_cache(AvahiWideAreaLookupEngine *e, AvahiRecord *r) {
 
     c->record = avahi_record_ref(r);
 
-    gettimeofday(&c->timestamp, NULL);
+    avahi_now(&c->timestamp);
     c->expiry = c->timestamp;
     avahi_timeval_add(&c->expiry, r->ttl * 1000000);
 

--- a/avahi-core/wide-area.c
+++ b/avahi-core/wide-area.c
@@ -48,8 +48,8 @@ struct AvahiWideAreaCacheEntry {
     AvahiWideAreaLookupEngine *engine;
 
     AvahiRecord *record;
-    struct timeval timestamp;
-    struct timeval expiry;
+    struct AvahiTimeVal timestamp;
+    struct AvahiTimeVal expiry;
 
     AvahiTimeEvent *time_event;
 
@@ -173,7 +173,7 @@ static void lookup_stop(AvahiWideAreaLookup *l) {
 
 static void sender_timeout_callback(AvahiTimeEvent *e, void *userdata) {
     AvahiWideAreaLookup *l = userdata;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     assert(l);
 
@@ -207,7 +207,7 @@ AvahiWideAreaLookup *avahi_wide_area_lookup_new(
     AvahiWideAreaLookupCallback callback,
     void *userdata) {
 
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     AvahiWideAreaLookup *l, *t;
     uint8_t *p;
 

--- a/avahi-daemon/dbus-protocol.c
+++ b/avahi-daemon/dbus-protocol.c
@@ -161,7 +161,7 @@ static void reconnect_callback(AvahiTimeout *t, AVAHI_GCC_UNUSED void *userdata)
     assert(!server->bus);
 
     if (dbus_connect() < 0) {
-        struct timeval tv;
+        struct AvahiTimeVal tv;
         avahi_log_debug(__FILE__": Connection failed, retrying in %ims...", RECONNECT_MSEC);
         avahi_elapse_time(&tv, RECONNECT_MSEC, 0);
         server->poll_api->timeout_update(t, &tv);
@@ -190,7 +190,7 @@ static DBusHandlerResult msg_signal_filter_impl(AVAHI_GCC_UNUSED DBusConnection 
 /*                     dbus_message_get_member(m)); */
 
     if (dbus_message_is_signal(m, DBUS_INTERFACE_LOCAL, "Disconnected")) {
-        struct timeval tv;
+        struct AvahiTimeVal tv;
 
         if (server->reconnect) {
             avahi_log_warn("Disconnected from D-Bus, trying to reconnect in %ims...", RECONNECT_MSEC);
@@ -1369,7 +1369,7 @@ int dbus_protocol_setup(const AvahiPoll *poll_api,
     server->n_entries_per_entry_group_max = _n_entries_per_entry_group_max > 0 ? _n_entries_per_entry_group_max : DEFAULT_ENTRIES_PER_ENTRY_GROUP_MAX;
 
     if (dbus_connect() < 0) {
-        struct timeval tv;
+        struct AvahiTimeVal tv;
 
         if (!force)
             goto fail;

--- a/avahi-glib/glib-watch-test.c
+++ b/avahi-glib/glib-watch-test.c
@@ -53,7 +53,7 @@ static void callback(AvahiWatch *w, int fd, AvahiWatchEvent event, AVAHI_GCC_UNU
 }
 
 static void wakeup(AvahiTimeout *t, AVAHI_GCC_UNUSED void *userdata) {
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     static int i = 0;
 
     printf("Wakeup #%i\n", i++);
@@ -67,7 +67,7 @@ static void wakeup(AvahiTimeout *t, AVAHI_GCC_UNUSED void *userdata) {
 
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     AvahiGLibPoll *g;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     g = avahi_glib_poll_new(NULL, G_PRIORITY_DEFAULT);
     assert(g);

--- a/avahi-glib/glib-watch.c
+++ b/avahi-glib/glib-watch.c
@@ -45,7 +45,7 @@ struct AvahiTimeout {
     gboolean dead;
 
     gboolean enabled;
-    struct timeval expiry;
+    struct AvahiTimeVal expiry;
 
     AvahiTimeoutCallback callback;
     void  *userdata;
@@ -163,7 +163,7 @@ static void watch_free(AvahiWatch *w) {
     w->glib_poll->watch_req_cleanup = TRUE;
 }
 
-static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata) {
+static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct AvahiTimeVal *tv, AvahiTimeoutCallback callback, void *userdata) {
     AvahiTimeout *t;
     AvahiGLibPoll *g;
 
@@ -190,7 +190,7 @@ static AvahiTimeout* timeout_new(const AvahiPoll *api, const struct timeval *tv,
     return t;
 }
 
-static void timeout_update(AvahiTimeout *t, const struct timeval *tv) {
+static void timeout_update(AvahiTimeout *t, const struct AvahiTimeVal *tv) {
     assert(t);
     assert(!t->dead);
 
@@ -266,7 +266,7 @@ static gboolean prepare_func(GSource *source, gint *timeout) {
         cleanup_timeouts(g, 0);
 
     if ((next_timeout = find_next_timeout(g))) {
-        struct timeval tvnow;
+        struct AvahiTimeVal tvnow;
         AvahiUsec usec;
 
         usec = avahi_timeval_diff(&next_timeout->expiry, avahi_now(&tvnow));
@@ -291,7 +291,7 @@ static gboolean check_func(GSource *source) {
     g_assert(g);
 
     if ((next_timeout = find_next_timeout(g))) {
-        struct timeval tvnow;
+        struct AvahiTimeVal tvnow;
 
         if (avahi_timeval_compare(&next_timeout->expiry, avahi_now(&tvnow)) <= 0)
             return TRUE;
@@ -312,7 +312,7 @@ static gboolean dispatch_func(GSource *source, AVAHI_GCC_UNUSED GSourceFunc call
     g_assert(g);
 
     if ((next_timeout = find_next_timeout(g))) {
-        struct timeval tvnow;
+        struct AvahiTimeVal tvnow;
 
         if (avahi_timeval_compare(&next_timeout->expiry, avahi_now(&tvnow)) < 0) {
             start_timeout_callback(next_timeout);

--- a/avahi-glib/glib-watch.c
+++ b/avahi-glib/glib-watch.c
@@ -266,15 +266,10 @@ static gboolean prepare_func(GSource *source, gint *timeout) {
         cleanup_timeouts(g, 0);
 
     if ((next_timeout = find_next_timeout(g))) {
-        GTimeVal now;
         struct timeval tvnow;
         AvahiUsec usec;
 
-        g_source_get_current_time(source, &now);
-        tvnow.tv_sec = now.tv_sec;
-        tvnow.tv_usec = now.tv_usec;
-
-        usec = avahi_timeval_diff(&next_timeout->expiry, &tvnow);
+        usec = avahi_timeval_diff(&next_timeout->expiry, avahi_now(&tvnow));
 
         if (usec <= 0) {
 	   *timeout = 0;
@@ -296,13 +291,9 @@ static gboolean check_func(GSource *source) {
     g_assert(g);
 
     if ((next_timeout = find_next_timeout(g))) {
-        GTimeVal now;
         struct timeval tvnow;
-        g_source_get_current_time(source, &now);
-        tvnow.tv_sec = now.tv_sec;
-        tvnow.tv_usec = now.tv_usec;
 
-        if (avahi_timeval_compare(&next_timeout->expiry, &tvnow) <= 0)
+        if (avahi_timeval_compare(&next_timeout->expiry, avahi_now(&tvnow)) <= 0)
             return TRUE;
     }
 
@@ -321,13 +312,9 @@ static gboolean dispatch_func(GSource *source, AVAHI_GCC_UNUSED GSourceFunc call
     g_assert(g);
 
     if ((next_timeout = find_next_timeout(g))) {
-        GTimeVal now;
         struct timeval tvnow;
-        g_source_get_current_time(source, &now);
-        tvnow.tv_sec = now.tv_sec;
-        tvnow.tv_usec = now.tv_usec;
 
-        if (avahi_timeval_compare(&next_timeout->expiry, &tvnow) < 0) {
+        if (avahi_timeval_compare(&next_timeout->expiry, avahi_now(&tvnow)) < 0) {
             start_timeout_callback(next_timeout);
             return TRUE;
         }

--- a/avahi-qt/qt-watch.cpp
+++ b/avahi-qt/qt-watch.cpp
@@ -1,16 +1,16 @@
 /***
   This file is part of avahi.
- 
+
   avahi is free software; you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation; either version 2.1 of the
   License, or (at your option) any later version.
- 
+
   avahi is distributed in the hope that it will be useful, but WITHOUT
   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
   or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
   Public License for more details.
- 
+
   You should have received a copy of the GNU Lesser General Public
   License along with avahi; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
@@ -30,7 +30,7 @@
 #include <avahi-common/timeval.h>
 #include "qt-watch.h"
 
-class AvahiWatch : public QObject 
+class AvahiWatch : public QObject
 {
     Q_OBJECT
 public:
@@ -54,18 +54,18 @@ private:
     bool m_incallback;
 };
 
-class AvahiTimeout : public QObject 
+class AvahiTimeout : public QObject
 {
     Q_OBJECT
-    
+
 public:
-    AvahiTimeout(const struct timeval* tv, AvahiTimeoutCallback callback, void* userdata);
+    AvahiTimeout(const struct AvahiTimeVal* tv, AvahiTimeoutCallback callback, void* userdata);
     ~AvahiTimeout() {}
-    void update(const struct timeval* tv);
-    
+    void update(const struct AvahiTimeVal* tv);
+
 private slots:
     void timeout();
-    
+
 private:
     QTimer m_timer;
     AvahiTimeoutCallback m_callback;
@@ -74,7 +74,7 @@ private:
 
 
 
-AvahiWatch::AvahiWatch(int fd, AvahiWatchEvent event, AvahiWatchCallback callback, void* userdata) : 
+AvahiWatch::AvahiWatch(int fd, AvahiWatchEvent event, AvahiWatchCallback callback, void* userdata) :
     m_in(0), m_out(0),  m_callback(callback), m_fd(fd), m_userdata(userdata), m_incallback(false)
 {
     setWatchedEvents(event);
@@ -96,21 +96,21 @@ void AvahiWatch::gotOut()
     m_incallback=false;
 }
 
-void AvahiWatch::setWatchedEvents(AvahiWatchEvent event) 
+void AvahiWatch::setWatchedEvents(AvahiWatchEvent event)
 {
     if (!(event & AVAHI_WATCH_IN)) { delete m_in; m_in=0; }
     if (!(event & AVAHI_WATCH_OUT)) { delete m_out; m_out=0; }
-    if (event & AVAHI_WATCH_IN) { 
+    if (event & AVAHI_WATCH_IN) {
 	m_in = new QSocketNotifier(m_fd,QSocketNotifier::Read, this);
 	connect(m_in,SIGNAL(activated(int)),SLOT(gotIn()));
     }
-    if (event & AVAHI_WATCH_OUT) { 
+    if (event & AVAHI_WATCH_OUT) {
 	m_out = new QSocketNotifier(m_fd,QSocketNotifier::Write, this);
 	connect(m_out,SIGNAL(activated(int)),SLOT(gotOut()));
     }
-}    
+}
 
-AvahiTimeout::AvahiTimeout(const struct timeval* tv, AvahiTimeoutCallback callback, void *userdata) : 
+AvahiTimeout::AvahiTimeout(const struct AvahiTimeVal* tv, AvahiTimeoutCallback callback, void *userdata) :
     m_callback(callback), m_userdata(userdata)
 {
     connect(&m_timer, SIGNAL(timeout()), this, SLOT(timeout()));
@@ -120,7 +120,7 @@ AvahiTimeout::AvahiTimeout(const struct timeval* tv, AvahiTimeoutCallback callba
     update(tv);
 }
 
-void AvahiTimeout::update(const struct timeval *tv)
+void AvahiTimeout::update(const struct AvahiTimeVal *tv)
 {
     m_timer.stop();
     if (tv) {
@@ -138,44 +138,44 @@ void AvahiTimeout::timeout()
     m_callback(this,m_userdata);
 }
 
-static AvahiWatch* q_watch_new(const AvahiPoll *api, int fd, AvahiWatchEvent event, AvahiWatchCallback callback, 
-    void *userdata) 
+static AvahiWatch* q_watch_new(const AvahiPoll *api, int fd, AvahiWatchEvent event, AvahiWatchCallback callback,
+    void *userdata)
 {
     return new AvahiWatch(fd, event, callback, userdata);
 }
 
-static void q_watch_update(AvahiWatch *w, AvahiWatchEvent events) 
+static void q_watch_update(AvahiWatch *w, AvahiWatchEvent events)
 {
     w->setWatchedEvents(events);
 }
 
-static AvahiWatchEvent q_watch_get_events(AvahiWatch *w) 
+static AvahiWatchEvent q_watch_get_events(AvahiWatch *w)
 {
     return w->getEvents();
 }
-    
-static void q_watch_free(AvahiWatch *w) 
+
+static void q_watch_free(AvahiWatch *w)
 {
     delete w;
 }
-    
-static AvahiTimeout* q_timeout_new(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, 
-    void *userdata) 
+
+static AvahiTimeout* q_timeout_new(const AvahiPoll *api, const struct AvahiTimeVal *tv, AvahiTimeoutCallback callback,
+    void *userdata)
 {
     return new AvahiTimeout(tv, callback, userdata);
 }
 
-static void q_timeout_update(AvahiTimeout *t, const struct timeval *tv) 
+static void q_timeout_update(AvahiTimeout *t, const struct AvahiTimeVal *tv)
 {
     t->update(tv);
 }
 
-static void q_timeout_free(AvahiTimeout *t) 
+static void q_timeout_free(AvahiTimeout *t)
 {
     delete t;
 }
 
-const AvahiPoll* avahi_qt_poll_get(void) 
+const AvahiPoll* avahi_qt_poll_get(void)
 {
     static const AvahiPoll qt_poll = {
         NULL,

--- a/configure.ac
+++ b/configure.ac
@@ -347,7 +347,7 @@ fi
 
 # Checks for header files.
 AC_HEADER_STDC
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h limits.h netinet/in.h stdlib.h string.h sys/ioctl.h sys/socket.h sys/time.h unistd.h netdb.h syslog.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h limits.h netinet/in.h stdlib.h string.h sys/ioctl.h sys/socket.h sys/time.h time.h unistd.h netdb.h syslog.h])
 AC_HEADER_STDBOOL
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -368,7 +368,7 @@ AC_FUNC_SELECT_ARGTYPES
 # whether libc's malloc does too. (Same for realloc.)
 #AC_FUNC_MALLOC
 #AC_FUNC_REALLOC
-AC_CHECK_FUNCS([gethostname memchr memmove memset mkdir select socket strchr strcspn strdup strerror strrchr strspn strstr uname setresuid setreuid setresgid setregid strcasecmp gettimeofday putenv strncasecmp strlcpy gethostbyname seteuid setegid setproctitle getprogname])
+AC_CHECK_FUNCS([clock_gettime gethostname memchr memmove memset mkdir select socket strchr strcspn strdup strerror strrchr strspn strstr uname setresuid setreuid setresgid setregid strcasecmp gettimeofday putenv strncasecmp strlcpy gethostbyname seteuid setegid setproctitle getprogname])
 
 AC_FUNC_CHOWN
 AC_FUNC_STAT

--- a/examples/client-publish-service.c
+++ b/examples/client-publish-service.c
@@ -233,7 +233,7 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char*argv[]) {
     AvahiClient *client = NULL;
     int error;
     int ret = 1;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
 
     /* Allocate main loop object */
     if (!(simple_poll = avahi_simple_poll_new())) {

--- a/examples/glib-integration.c
+++ b/examples/glib-integration.c
@@ -75,7 +75,7 @@ main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[])
     const AvahiPoll *poll_api;
     AvahiGLibPoll *glib_poll;
     AvahiClient *client;
-    struct timeval tv;
+    struct AvahiTimeVal tv;
     const char *version;
     int error;
 
@@ -95,7 +95,7 @@ main (AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[])
             0);                                     /* "jitter" - Random additional delay from 0 to this value */
 
     poll_api->timeout_new (poll_api,                /* The AvahiPoll object */
-                      &tv,                          /* struct timeval indicating when to go activate */
+                      &tv,                          /* struct AvahiTimeVal indicating when to go activate */
                       avahi_timeout_event,          /* Pointer to function to call */
                       NULL);                        /* User data to pass to function */
 


### PR DESCRIPTION
Changes avahi to use a monotonic clock (clock_gettime() + CLOCK_MONOTONIC) for timers on systems that support it instead of gettimeofday(). This prevents changes to the system clock from disrupting the avahi timers. In particular, if the system clock is set backward by a significant amount, it can prevent avahi from sending any queries or responses because the old entries in the respective history lists won't time out.